### PR TITLE
fix: extract titles via pyquery

### DIFF
--- a/slidesaver.py
+++ b/slidesaver.py
@@ -18,8 +18,8 @@ def main():
     if resp.status_code == 200:
         if 'slideshare.net' in link:
             query = pyquery.PyQuery(resp.text)
-            title = re.findall('<h1.*?>(.*)</h1>', resp.text)
-            title = re.sub(r'[^a-zA-Z0-9%!-_*.]', ' ', title[0])
+            title = query('h1:first').text()
+            title = re.sub(r'[^a-zA-Z0-9%!-_*.]', ' ', title)
             if resp.text.find('"type":"presentation"') != -1:
                 images = query('img.slide_image')
                 c = reportlab.pdfgen.canvas.Canvas(title + '.pdf')
@@ -55,8 +55,8 @@ def main():
                     print(link)
         if 'speakerdeck.com' in link:
             query = pyquery.PyQuery(resp.text)
-            title = re.findall('<h1>(.*)</h1>', resp.text)
-            title = re.sub(r'[^a-zA-Z0-9]', ' ', title[1])
+            title = query('h1')[1].text
+            title = re.sub(r'[^a-zA-Z0-9]', ' ', title)
             embeds = query('div.speakerdeck-embed')
             for embed in embeds:
                 code = embed.attrib['data-id']


### PR DESCRIPTION
titles on slideshare are now `<span>` tags wrapped into `<h1>` and
containing linefeeds; it is easily solved via pyquery's `text()` method;
pyquery is also more stable and is less likely to break in the future
compared to regexs; modified title extraction for speakerdeck too for
consistency;

alternative is to extract these spans which now have 'j-title-breadcrumb' class,
but i'd rather stick with `<h1>`
